### PR TITLE
Fixed issue when used in table view with sections

### DIFF
--- a/Library/DNSSwipeableCell.m
+++ b/Library/DNSSwipeableCell.m
@@ -209,7 +209,7 @@
     
     //Update the origin and size to make sure that everything is the size it needs to be
     CGFloat xOrigin = previousMinX - CGRectGetWidth(button.frame);
-    button.frame = CGRectMake(xOrigin, 0, CGRectGetWidth(button.frame), CGRectGetHeight(self.frame));
+    button.frame = CGRectMake(xOrigin, 0, CGRectGetWidth(button.frame), CGRectGetHeight(self.contentView.frame));
     
     //Add tap target
     [button addTarget:self action:@selector(buttonClicked:) forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
When used in table view with sections and section headers UITableViewCell contentView gets 0.5 point cut off from the bottom.
So if cell height is 80.0 points the contentView will be 79.5 points. The button height will be 80.0 and the bottom 0.5 points will be visible after swiping back.
To fix it button should take it's frame height from contentView.frame rather that from view.frame.