### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The crux of the problem is that while adding a delete button is super-easy, addi
 
 I've refactored the code that was included in the tutorial, which is is more meant as an exercise in helping n00bs dive into figuring out how Apple's code works under the hood, into this library, which I'm hoping will be helpful for anyone dealing with this in production code. 
 
-##The Biggest Changes
+## The Biggest Changes
 * Removed dependency on the storyboard (though you can still use one if you like)
 * Made the `myContentView` public so the cell could be subclassed and recycled more easily.
 * Beefed up delegate to handle an arbitrary number of buttons
@@ -21,21 +21,21 @@ I've refactored the code that was included in the tutorial, which is is more mea
 * Added a sample subclass.
 * Added a bunch of photos of my cat, because the internet loves cats. 
 
-#Notes on Usage 
+# Notes on Usage 
 
 * If you're using an accessory view via `accessoryType`, that view will automatically be removed and replaced when the cell is opened and closed (respectively). 
 * If you're using a custom background color for your `myContentView` along with an accessory, remember to set that same color as the background color for the cell itself, or the accessory's going to have a different background color.
 * If you're using a cell from a storyboard or a `.xib`, you have to add a `myContentView` view, and hook up the `NSLayoutConstraint` outlets to the left and right constraints. See the sample project for an example of how to set this up.
 * If you're using a cell from a storyboard or a `.xib`, make sure you're sending any calls to the superclass during setup which need `myContentView` to not be `nil` through `awakeFromNib` instead of `initWithCoder:`, since the `IBOutlet` won't be hooked up until `awakeFromNib` has fired. 
 
-##//TODOs
+## //TODOs
 * Support for swiping in both directions ([issue](https://github.com/designatednerd/DNSSwipeableTableCell/issues/7))
 * Support for iOS 8 style cell actions ([issue](https://github.com/designatednerd/DNSSwipeableTableCell/issues/15))
 * ??? - File an issue!
 
-##Additional Contributors
+## Additional Contributors
 * [Mark Flowers](https://github.com/markflowers) - Improved fixes for tableview slop, removed index path hack, defaults for numerous previously required methods, and better delegate methods.
 
 
-##Photos
+## Photos
 All photos Copyright Ellen Shapiro. If you want to see more photos of my jerkface cat, Chaplin, follow me on [Instagram](http://instagram.com/loudguitars).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
